### PR TITLE
Add scroll-triggered name display in header

### DIFF
--- a/patrickrottman/src/app/components/header/header.component.html
+++ b/patrickrottman/src/app/components/header/header.component.html
@@ -1,7 +1,10 @@
-<mat-toolbar class="header">
+<mat-toolbar class="header" [class.scrolled]="isScrolled">
   <div class="header-content">
-    <div class="profile-image" (click)="navigateHome()" role="button" tabindex="0"></div>
-    
+    <div class="profile-section" (click)="navigateHome()" role="button" tabindex="0">
+      <div class="profile-image"></div>
+      <span class="profile-name" [class.visible]="isScrolled">Patrick Rottman</span>
+    </div>
+
     <div class="nav-links">
       <a mat-button (click)="scrollToSection('summary')">Summary</a>
       <a mat-button (click)="scrollToSection('experience')">Experience</a>

--- a/patrickrottman/src/app/components/header/header.component.scss
+++ b/patrickrottman/src/app/components/header/header.component.scss
@@ -20,18 +20,46 @@
     margin: 0 auto;
   }
 
-  .profile-image {
-    width: 50px;
-    height: 50px;
-    border-radius: 50%;
-    background-image: url('https://ca.slack-edge.com/T03SGJX1Q-U03F84DFM7Y-1a85a174f606-512');
-    background-size: cover;
-    background-position: center;
+  .profile-section {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
     cursor: pointer;
     transition: transform 0.2s ease;
 
     &:hover {
-      transform: scale(1.05);
+      .profile-image {
+        transform: scale(1.05);
+      }
+    }
+
+    .profile-image {
+      width: 50px;
+      height: 50px;
+      border-radius: 50%;
+      background-image: url('https://ca.slack-edge.com/T03SGJX1Q-U03F84DFM7Y-1a85a174f606-512');
+      background-size: cover;
+      background-position: center;
+      transition: transform 0.2s ease;
+      flex-shrink: 0;
+    }
+
+    .profile-name {
+      font-size: 1.125rem;
+      font-weight: 600;
+      color: var(--text-color);
+      white-space: nowrap;
+      opacity: 0;
+      transform: translateX(-10px);
+      transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+      max-width: 0;
+      overflow: hidden;
+
+      &.visible {
+        opacity: 1;
+        transform: translateX(0);
+        max-width: 200px;
+      }
     }
   }
 

--- a/patrickrottman/src/app/components/header/header.component.ts
+++ b/patrickrottman/src/app/components/header/header.component.ts
@@ -23,11 +23,23 @@ import { Router, RouterModule } from '@angular/router';
   styleUrl: './header.component.scss'
 })
 export class HeaderComponent {
+  isScrolled = false;
+
   constructor(
     public themeService: ThemeService,
     private viewportScroller: ViewportScroller,
     private router: Router
-  ) {}
+  ) {
+    this.setupScrollListener();
+  }
+
+  private setupScrollListener(): void {
+    if (typeof window !== 'undefined') {
+      window.addEventListener('scroll', () => {
+        this.isScrolled = window.scrollY > 100;
+      });
+    }
+  }
 
   scrollToSection(elementId: string): void {
     if (this.router.url !== '/') {

--- a/patrickrottman/src/app/components/skills/skills.component.ts
+++ b/patrickrottman/src/app/components/skills/skills.component.ts
@@ -12,6 +12,12 @@ import { MatCardModule } from '@angular/material/card';
 })
 export class SkillsComponent {
   skills = [
+    { icon: 'extension', name: 'MCP Engineering' },
+    { icon: 'hub', name: 'Agent Orchestration' },
+    { icon: 'psychology', name: 'LLM Integration' },
+    { icon: 'smart_toy', name: 'AI/ML' },
+    { icon: 'architecture', name: 'Prompt Engineering' },
+    { icon: 'category', name: 'RAG Systems' },
     { icon: 'code', name: 'C#' },
     { icon: 'code', name: 'TypeScript' },
     { icon: 'javascript', name: 'JavaScript' },
@@ -29,12 +35,6 @@ export class SkillsComponent {
     { icon: 'storage', name: 'Redis' },
     { icon: 'merge', name: 'Git' },
     { icon: 'memory', name: 'IoT' },
-    { icon: 'brush', name: 'Figma' },
-    { icon: 'extension', name: 'MCP Engineering' },
-    { icon: 'hub', name: 'Agent Orchestration' },
-    { icon: 'psychology', name: 'LLM Integration' },
-    { icon: 'smart_toy', name: 'AI/ML' },
-    { icon: 'architecture', name: 'Prompt Engineering' },
-    { icon: 'category', name: 'RAG Systems' }
+    { icon: 'brush', name: 'Figma' }
   ];
 } 

--- a/patrickrottman/src/app/components/skills/skills.component.ts
+++ b/patrickrottman/src/app/components/skills/skills.component.ts
@@ -29,6 +29,12 @@ export class SkillsComponent {
     { icon: 'storage', name: 'Redis' },
     { icon: 'merge', name: 'Git' },
     { icon: 'memory', name: 'IoT' },
-    { icon: 'brush', name: 'Figma' }
+    { icon: 'brush', name: 'Figma' },
+    { icon: 'extension', name: 'MCP Engineering' },
+    { icon: 'hub', name: 'Agent Orchestration' },
+    { icon: 'psychology', name: 'LLM Integration' },
+    { icon: 'smart_toy', name: 'AI/ML' },
+    { icon: 'architecture', name: 'Prompt Engineering' },
+    { icon: 'category', name: 'RAG Systems' }
   ];
 } 


### PR DESCRIPTION
## Summary
Adds smooth scroll-triggered animation that displays 'Patrick Rottman' next to the profile picture in the header after scrolling 100px.

## Changes
- Added scroll detection at 100px threshold
- Name smoothly fades in next to profile pic when scrolled
- Slide and fade animation (opacity + translateX transition)
- Profile pic and name work as unified clickable element
- Responsive sizing works across all screen sizes

## Behavior
- **Not scrolled**: Profile picture only (clean, minimal)
- **Scrolled > 100px**: Name slides in from left with fade effect
- **All screen sizes**: Same behavior, properly sized

## Technical Details
- 300ms cubic-bezier transition for smooth animation
- SSR-safe with window check
- No layout shift (uses max-width transition)
- Maintains existing hover effects on profile pic